### PR TITLE
Lazy load runtime dependency

### DIFF
--- a/lib/Dist/Zilla/App/Command/dumpphases.pm
+++ b/lib/Dist/Zilla/App/Command/dumpphases.pm
@@ -37,7 +37,6 @@ C<ANSI_COLORS_DISABLED=1 dzil dumpphases>
 use Dist::Zilla::App -command;
 use Moose::Autobox;
 use Try::Tiny;
-use Term::ANSIColor qw( colored );
 use Scalar::Util qw( blessed );
 
 ## no critic ( ProhibitAmbiguousNames)
@@ -112,6 +111,9 @@ sub execute {
   my $zilla = $self->zilla;
 
   my $phases = $self->_phases;
+
+  require Term::ANSIColor;
+  Term::ANSIColor->import('colored');
 
   for my $phase ( @{$phases} ) {
     my ( $label, $roles, $description ) = @{$phase};


### PR DESCRIPTION
All DZ::App::Command modules are loaded for any command run. This means that `dumpphases` is loaded even when we run `dzil test`. So it is important to avoid loading external modules unless the command is really used.

This patch delays the loading of `Term::ANSIColor` to the runtime for `dumpphases`.
