### PR TITLE
add color for the MSWin32 platform

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -80,6 +80,7 @@ normal_form = numify
 replacer = replace_with_blank
 
 [AutoPrereqs / @Author::KENTNL/AutoPrereqs]
+skips = ^Win32::Console::ANSI$
 
 [Prereqs / @Author::KENTNL/BundleDevelSuggests]
 -phase = develop

--- a/dist.ini.meta
+++ b/dist.ini.meta
@@ -18,6 +18,7 @@ bumpversions      = 1
 copyfiles         = LICENSE
 srcreadme         = mkdn
 twitter_extra_hash_tags = #distzilla
+auto_prereqs_skip = ^Win32::Console::ANSI$
 
 ; version_major     = 0
 ; version_minor     = 1

--- a/lib/Dist/Zilla/dumpphases/Role/Theme/SimpleColor.pm
+++ b/lib/Dist/Zilla/dumpphases/Role/Theme/SimpleColor.pm
@@ -36,7 +36,7 @@ requires 'color';
 
 ## no critic ( RequireArgUnpacking )
 sub _colored {
-  require Term::ANSIColor;
+  require Term::ANSIColor; () = eval { require Win32::Console::ANSI } if 'MSWin32' eq $^O;
   goto \&Term::ANSIColor::colored;
 }
 


### PR DESCRIPTION
.# Discussion

Term::ANSIColor doesn't include MSWin32 support by default. And, unfortunately, it seems
that perl-porters don't want to include it (see https://rt.cpan.org/Ticket/Display.html?id=44807
@@ http://archive.is/gqB1N). So, to support the platform, Win32::Console::ANSI must be
used whenever Term::ANSIColor is loaded. It's tiresome but has a simple fix.

Adding `eval { require Win32::Console::ANSI }` after any require/use of Term::ANSIColor is
all that is needed for MSWin32 support. Since Win32::Console::ANSI can only be installed
on MSWin32 platforms, no `$^O eq 'MSWin32'` test is needed.
